### PR TITLE
Typo in configuration of variables for the end-entity in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ playbook: tests/test.yml
       ca_organization_name: "Red Hat Consulting"
       ca_organizational_unit_name: "Red Hat Consulting Certificate Authority"
       endentity_list:
-        certificate_file_name: It should have an identifier name without any special character or whitespace.  
+        - certificate_file_name: It should have an identifier name without any special character or whitespace.  
           endentity_common_name: end-entity CN
           dns_server:
             - DNS list that certificate should have

--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ ti6d6Nu8JqlWT2PtbkIO2NOGykB9Zs33EDoTbfaTpI1HAPYzO/coPQDvWbS38rPT
 9MLw6ibcT0w8JMg0VDQxVxz+TUNh8Sn48F3E/8NxbeIAeIiDgv3ubyW5c8k=
 -----END RSA PRIVATE KEY-----
 
-
 $ openssl req -text -noout -verify -in /tmp/ca/rootCA/csr/ca-root.csr 
 verify OK
 Certificate Request:


### PR DESCRIPTION
While modifying the variables in `defaults/main.yml` I was following the structure depicted in the README file but I realized a hypen (-) was missing, when declaring the list of end entities